### PR TITLE
RustySearchの起動スクリプトを追加し、Goサーバーのログ出力を強化。Rust検索アダプターの初期化時にバイナリパスをログに記録し…

### DIFF
--- a/go-server/cmd/main.go
+++ b/go-server/cmd/main.go
@@ -12,6 +12,12 @@ import (
 )
 
 func main() {
+	log.SetOutput(os.Stdout)
+	log.SetPrefix("[RustySearch] ")
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+
+	log.Println("Starting RustySearch server...")
+
 	binaryPath := os.Getenv("SEARCH_ROOT")
 	if binaryPath == "" {
 		log.Println("SEARCH_ROOT env variable is empty, so default value was set")
@@ -19,6 +25,19 @@ func main() {
 		exeDir := filepath.Dir(exePath)
 		binaryPath = filepath.Join(exeDir, "..", "rust-search", "target", "release", "rust_search")
 	}
+
+	absPath, err := filepath.Abs(binaryPath)
+	if err == nil {
+		log.Printf("Absolute path to search binary: %s", absPath)
+		_, err := os.Stat(absPath)
+		if err != nil {
+			log.Printf("Warning: Search binary not found at path: %s, Error: %v", absPath, err)
+		} else {
+			log.Printf("Search binary exists at path: %s", absPath)
+			binaryPath = absPath
+		}
+	}
+
 	seacher := infrastructure.NewRustSearchAdapter(binaryPath)
 	searchInteractor := usecase.NewSearchInteractor(seacher)
 	handler := delivery.NewHTTPHandler(searchInteractor)
@@ -26,5 +45,6 @@ func main() {
 	e := echo.New()
 	handler.RegisterRoutes(e)
 
+	log.Println("Server is ready at http://localhost:8080")
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/go-server/infrastructure/rust_search_adapter.go
+++ b/go-server/infrastructure/rust_search_adapter.go
@@ -3,6 +3,7 @@ package infrastructure
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os/exec"
 	"sort"
 	"strings"
@@ -16,6 +17,7 @@ type RustSearchAdapter struct {
 }
 
 func NewRustSearchAdapter(binaryPath string) *RustSearchAdapter {
+	log.Printf("RustSearchAdapter initialized with binary path: %s", binaryPath)
 	return &RustSearchAdapter{binaryPath: binaryPath}
 }
 
@@ -25,6 +27,7 @@ func (r *RustSearchAdapter) Search(query model.SearchQuery) ([]model.SearchResul
 		args = append(args, "--fuzzy")
 	}
 
+	log.Printf("Executing Rust search: %s %v", r.binaryPath, args)
 	cmd := exec.Command(r.binaryPath, args...)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -35,10 +38,12 @@ func (r *RustSearchAdapter) Search(query model.SearchQuery) ([]model.SearchResul
 		if errMsg == "" {
 			errMsg = err.Error()
 		}
+		log.Printf("Rust search error: %s", errMsg)
 		return nil, fmt.Errorf("rust search error: %s", errMsg)
 	}
 
 	output := outBuf.String()
+	log.Printf("Rust search output received: %d bytes", len(output))
 	var results []model.SearchResult
 	lines := strings.Split(output, "\n")
 	for _, line := range lines {
@@ -101,5 +106,6 @@ func (r *RustSearchAdapter) Search(query model.SearchQuery) ([]model.SearchResul
 		return queryInI && !queryInJ
 	})
 
+	log.Printf("Processed search results: %d items", len(results))
 	return results, nil
 }

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# エラーが発生したらスクリプトを停止
+set -e
+
+echo "RustySearch MVPの起動スクリプト"
+echo "==============================="
+
+# 現在のディレクトリを基準にパスを設定
+PROJECT_ROOT=$(pwd)
+RUST_BIN="$PROJECT_ROOT/rust-search/target/release/fixer"
+GO_SERVER_DIR="$PROJECT_ROOT/go-server/cmd"
+PORT=8080
+
+# プロセスの状態を確認
+echo "0. プロセスの状態を確認中..."
+PROCESS_EXISTS=false
+
+# 8080ポートを使用しているプロセスを確認
+if command -v lsof >/dev/null 2>&1; then
+  EXISTING_PID=$(lsof -ti:${PORT} 2>/dev/null)
+  if [ ! -z "$EXISTING_PID" ]; then
+    PROCESS_EXISTS=true
+    echo "ポート ${PORT} で実行中のプロセス ($EXISTING_PID) を終了します"
+    kill -9 $EXISTING_PID || true
+  fi
+fi
+
+# go runプロセスの確認
+GO_PID=$(pgrep -f "go run main.go" 2>/dev/null)
+if [ ! -z "$GO_PID" ]; then
+  PROCESS_EXISTS=true
+  echo "go run プロセス ($GO_PID) を終了します"
+  pkill -f "go run main.go" || true
+fi
+
+# プロセスが存在した場合のみスリープ
+if [ "$PROCESS_EXISTS" = true ]; then
+  echo "プロセス終了後、1秒待機します..."
+  sleep 1
+else
+  echo "実行中のプロセスはありません。続行します..."
+fi
+
+echo "1. Rustバイナリのビルド..."
+cd "$PROJECT_ROOT/rust-search"
+cargo build --release
+
+echo "2. Rustバイナリの確認: $RUST_BIN"
+if [ ! -f "$RUST_BIN" ]; then
+  echo "エラー: Rustバイナリが見つかりません"
+  exit 1
+fi
+
+echo "3. Goサーバーの起動..."
+cd "$GO_SERVER_DIR"
+SEARCH_ROOT="$RUST_BIN" go run main.go

--- a/rust-search/Cargo.lock
+++ b/rust-search/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "jobserver",
  "libc",
@@ -153,9 +153,9 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
  "serde",
@@ -186,7 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -220,9 +220,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fs4"
@@ -230,8 +230,8 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
 dependencies = [
- "rustix",
- "windows-sys 0.52.0",
+ "rustix 0.38.44",
+ "windows-sys",
 ]
 
 [[package]]
@@ -256,14 +256,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -358,6 +358,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "log"
@@ -514,6 +520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,8 +639,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.4.15",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
+ "windows-sys",
 ]
 
 [[package]]
@@ -865,16 +890,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix",
- "windows-sys 0.59.0",
+ "rustix 1.0.3",
+ "windows-sys",
 ]
 
 [[package]]
@@ -909,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -924,15 +948,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -952,11 +976,11 @@ checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "serde",
 ]
 
@@ -978,9 +1002,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -1075,7 +1099,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1089,15 +1113,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -1168,27 +1183,27 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1206,18 +1221,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.3"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.14+zstd.1.5.7"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/rust-search/src/main.rs
+++ b/rust-search/src/main.rs
@@ -1,20 +1,85 @@
-use std::{env, path::Path};
-
-use anyhow::Result;
+use anyhow::{Context, Result};
+use std::io::BufRead;
+use std::{env, fs, io, path::Path};
+use walkdir::WalkDir;
 
 fn main() -> Result<()> {
-    // コマンドライン引数で対象ディレクトリを指定。なければデフォルトで"./data"にする
     let args: Vec<String> = env::args().collect();
-    let target_dir = if args.len() > 1 { &args[1] } else { "./data" };
 
-    println!("Indexing files from directory: {}", target_dir);
+    if args.len() < 2 {
+        println!("使用法: {} <検索クエリ> [--fuzzy]", args[0]);
+        return Ok(());
+    }
 
-    // ディレクトリ内のファイルを再帰的にクロールして文書データに変換する
-    let document = crawl_directory(target_dir)?;
-    println!("Found {} documents.", document);
+    let query = &args[1];
+    let fuzzy_mode = args.len() > 2 && args[2] == "--fuzzy";
 
-    // Tantivyを利用してインデックスを作成する
+    // カレントディレクトリを検索対象とする
+    let target_dir = ".";
 
-    // 標準入力からクエリを受け取り検索を実施する
+    println!("検索結果:");
+    search_in_directory(target_dir, query, fuzzy_mode)?;
+
+    Ok(())
+}
+
+fn search_in_directory(dir: &str, query: &str, fuzzy_mode: bool) -> Result<()> {
+    for entry in WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+    {
+        let path = entry.path();
+
+        // バイナリファイルや特定の拡張子ファイルを除外
+        if should_skip_file(path) {
+            continue;
+        }
+
+        match fs::read_to_string(path) {
+            Ok(content) => {
+                search_in_content(path, &content, query, fuzzy_mode)?;
+            }
+            Err(_) => {
+                // ファイルの読み込みに失敗した場合は無視して続行
+                continue;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn should_skip_file(path: &Path) -> bool {
+    // バイナリファイル、巨大ファイル、特定の拡張子を持つファイルを除外
+    let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let skip_extensions = ["exe", "dll", "so", "dylib", "bin", "obj", "o", "a", "lib"];
+
+    // node_modules や .git ディレクトリ内のファイルを除外
+    let path_str = path.to_str().unwrap_or("");
+    if path_str.contains("node_modules") || path_str.contains(".git") {
+        return true;
+    }
+
+    skip_extensions.contains(&extension)
+}
+
+fn search_in_content(path: &Path, content: &str, query: &str, fuzzy_mode: bool) -> Result<()> {
+    let path_str = path.to_str().unwrap_or("unknown_path");
+    let query_lower = query.to_lowercase();
+
+    if fuzzy_mode {
+        // fuzzy-matcherを使用したファジー検索（今回はMVPなので実装しない）
+        // fuzzy_search_in_content(path_str, content, &query_lower)?;
+    } else {
+        // 単純なサブストリング検索
+        for (line_number, line) in content.lines().enumerate() {
+            let line_lower = line.to_lowercase();
+            if line_lower.contains(&query_lower) {
+                println!("{}:{}:{}", path_str, line_number + 1, line);
+            }
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
…、検索結果の処理状況をログ出力するように変更。Cargo.lockファイルの依存関係を更新。